### PR TITLE
remove center-items in examples wrapper

### DIFF
--- a/website/pages/designsystem/examples/[...slug].tsx
+++ b/website/pages/designsystem/examples/[...slug].tsx
@@ -21,7 +21,7 @@ const Page = ({ compkey }: { compkey: string }) => {
       <Heading level="1" size="medium" className="navds-sr-only">
         {compkey}
       </Heading>
-      <div className="flex w-full flex-col items-center justify-center p-4">
+      <div className="flex w-full flex-col justify-center p-4">
         <div className="inline-grid flex-wrap items-center gap-4">
           {CodePreview(compkey)}
         </div>


### PR DESCRIPTION
Vet ikke om dette er beste løsning på problemet, men atm er https://design.nav.no/designsystem/examples/accordion-example f'ed.